### PR TITLE
feat(cmd): add --mine flag to filter issues assigned to current user

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ var projectID int64
 var groupID int64
 var debugLevel string
 var markdownOutput bool
+var mineOption bool
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
@@ -42,6 +43,7 @@ func init() {
 	projectCmd.Flags().BoolVarP(&updatedAtOption, "updatedAt", "u", false, "issues filtered with updated date")
 	projectCmd.Flags().Int64VarP(&projectID, "id", "p", 0, "Project ID to get issues from")
 	projectCmd.Flags().BoolVarP(&markdownOutput, "markdown", "m", false, "output in markdown format")
+	projectCmd.Flags().BoolVarP(&mineOption, "mine", "M", false, "only issues assigned to current user")
 	rootCmd.AddCommand(projectCmd)
 
 	groupCmd.Flags().StringVarP(&interval, "i", "i", "", "interval, ex '/-1/ ::' to describe the interval of last month")
@@ -52,5 +54,6 @@ func init() {
 	groupCmd.Flags().BoolVarP(&updatedAtOption, "updatedAt", "u", false, "issues filtered with updated date")
 	groupCmd.Flags().Int64VarP(&groupID, "id", "g", 0, "Group ID to get issues from")
 	groupCmd.Flags().BoolVarP(&markdownOutput, "markdown", "m", false, "output in markdown format")
+	groupCmd.Flags().BoolVarP(&mineOption, "mine", "M", false, "only issues assigned to current user")
 	rootCmd.AddCommand(groupCmd)
 }

--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -26,6 +26,7 @@ type GetIssues struct {
 	FilterCreatedAtBefore time.Time
 	FilterUpdatedAtAfter  time.Time
 	FilterUpdatedAtBefore time.Time
+	AssigneeUsername      string
 }
 
 // GetIssuesOption is a functional option for configuring the GetIssues struct.
@@ -110,6 +111,13 @@ func WithClosedIssues() GetIssuesOption {
 	}
 }
 
+// WithAssigneeUsername filters issues by assignee username.
+func WithAssigneeUsername(assigneeUsername string) GetIssuesOption {
+	return func(g *GetIssues) {
+		g.AssigneeUsername = assigneeUsername
+	}
+}
+
 // GetIssues retrieves GitLab issues based on the provided options.
 func (a *App) GetIssues(opts ...GetIssuesOption) ([]*gitlab.Issue, error) {
 	g := &GetIssues{}
@@ -141,6 +149,10 @@ func applyIssueFilters(g *GetIssues, listOptions interface{}) {
 			&opts.UpdatedAfter,
 			&opts.UpdatedBefore,
 		)
+		// Add assignee username filter
+		if g.AssigneeUsername != "" {
+			opts.AssigneeUsername = &g.AssigneeUsername
+		}
 	case *gitlab.ListGroupIssuesOptions:
 		applyCommonFilters(
 			g,
@@ -150,6 +162,10 @@ func applyIssueFilters(g *GetIssues, listOptions interface{}) {
 			&opts.UpdatedAfter,
 			&opts.UpdatedBefore,
 		)
+		// Add assignee username filter
+		if g.AssigneeUsername != "" {
+			opts.AssigneeUsername = &g.AssigneeUsername
+		}
 	}
 }
 


### PR DESCRIPTION
Add --mine/-M flag to both project and group commands to filter
issues assigned to the currently authenticated GitLab user.

- Add mineOption flag variable and registration in cmd/root.go
- Add getCurrentUsername() helper to fetch current user via GitLab API
- Add addAssigneeFilterOptions() to build assignee filter options
- Add AssigneeUsername field to GetIssues struct
- Add WithAssigneeUsername() functional option
- Update applyIssueFilters() to apply assignee filter to both
  project and group issue queries

The implementation follows the existing functional options pattern
and works seamlessly with all other existing filters.