### PR TITLE
refactor(cmd): replace os.Exit calls with proper error propagation

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -128,10 +128,14 @@ func TestBuildIssueOptions(t *testing.T) {
 			openedOption = tt.openedOption
 			createdAtOption = tt.createdAtOption
 			updatedAtOption = tt.updatedAtOption
-			
+
 			// Call the function and ensure it doesn't panic
-			options := buildIssueOptions(tt.projectID, tt.groupID, time.Time{}, time.Time{})
-			
+			options, err := buildIssueOptions(tt.projectID, tt.groupID, time.Time{}, time.Time{})
+
+			if err != nil {
+				t.Errorf("buildIssueOptions() error = %v", err)
+			}
+
 			if options == nil {
 				t.Error("buildIssueOptions() returned nil")
 			}
@@ -165,9 +169,13 @@ func TestParseInterval(t *testing.T) {
 					t.Errorf("parseInterval() panicked: %v", r)
 				}
 			}()
-			
-			beginTime, endTime := parseInterval(tt.interval)
-			
+
+			beginTime, endTime, err := parseInterval(tt.interval)
+
+			if err != nil {
+				t.Errorf("parseInterval() error = %v", err)
+			}
+
 			if tt.interval == "" {
 				if !beginTime.IsZero() || !endTime.IsZero() {
 					t.Error("parseInterval() should return zero times for empty interval")
@@ -218,33 +226,39 @@ func TestSetupEnvironment(t *testing.T) {
 	t.Run("with token and URI", func(t *testing.T) {
 		os.Setenv("GITLAB_TOKEN", "test-token")
 		os.Setenv("GITLAB_URI", "https://gitlab.example.com")
-		
+
 		// This should not panic or exit
 		defer func() {
 			if r := recover(); r != nil {
 				t.Errorf("setupEnvironment() panicked: %v", r)
 			}
 		}()
-		
-		setupEnvironment()
-		
+
+		err := setupEnvironment()
+		if err != nil {
+			t.Errorf("setupEnvironment() error = %v", err)
+		}
+
 		if os.Getenv("GITLAB_URI") != "https://gitlab.example.com" {
 			t.Error("setupEnvironment() should preserve existing GITLAB_URI")
 		}
 	})
-	
+
 	t.Run("with token but no URI", func(t *testing.T) {
 		os.Setenv("GITLAB_TOKEN", "test-token")
 		os.Unsetenv("GITLAB_URI")
-		
+
 		defer func() {
 			if r := recover(); r != nil {
 				t.Errorf("setupEnvironment() panicked: %v", r)
 			}
 		}()
-		
-		setupEnvironment()
-		
+
+		err := setupEnvironment()
+		if err != nil {
+			t.Errorf("setupEnvironment() error = %v", err)
+		}
+
 		if os.Getenv("GITLAB_URI") != "https://gitlab.com" {
 			t.Error("setupEnvironment() should set default GITLAB_URI")
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"os"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
@@ -26,11 +26,11 @@ var rootCmd = &cobra.Command{
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
+func Execute() error {
+	if err := rootCmd.Execute(); err != nil {
+		return fmt.Errorf("command execution failed: %w", err)
 	}
+	return nil
 }
 
 func init() {

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -14,26 +14,30 @@ var whoamiCmd = &cobra.Command{
 	Use:   "whoami",
 	Short: "Display information about the authenticated GitLab user",
 	Long:  `Display information about the authenticated GitLab user including username, full name, email, and user ID.`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		// Setup environment (validates GITLAB_TOKEN and sets default GITLAB_URI)
-		setupEnvironment()
+		if err := setupEnvironment(); err != nil {
+			logrus.Errorln(err.Error())
+			return err
+		}
 
 		// Create GitLab client
 		gitlabClient, err := gitlab.NewClient(os.Getenv("GITLAB_TOKEN"), gitlab.WithBaseURL(os.Getenv("GITLAB_URI")))
 		if err != nil {
 			logrus.Errorln("Failed to create GitLab client:", err.Error())
-			os.Exit(1)
+			return fmt.Errorf("failed to create GitLab client: %w", err)
 		}
 
 		// Fetch current user information
 		user, _, err := gitlabClient.Users.CurrentUser()
 		if err != nil {
 			logrus.Errorln("Failed to fetch user information:", err.Error())
-			os.Exit(1)
+			return fmt.Errorf("failed to fetch user information: %w", err)
 		}
 
 		// Display user information
 		displayUserInfo(user)
+		return nil
 	},
 }
 

--- a/main.go
+++ b/main.go
@@ -1,8 +1,14 @@
 // Package main is the entry point for gitlab-issue-report application.
 package main
 
-import "github.com/sgaunet/gitlab-issue-report/cmd"
+import (
+	"os"
+
+	"github.com/sgaunet/gitlab-issue-report/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
- Convert all command handlers from Run to RunE functions
- Update utility functions to return errors instead of calling os.Exit
- Add proper error wrapping with context throughout
- Update findProjectID, getRemoteOrigin, and related helpers to return errors
- Modify setupEnvironment, getCurrentUsername, parseInterval, buildIssueOptions, and renderIssues to return errors
- Keep single os.Exit call in main.go as the application exit point
- Update integration tests to handle new function signatures
- Add static error variables for common error cases (errGitlabTokenNotSet, errGroupIDRequired)

Resolves #37