### PR TITLE
feat(api): add configurable timeout for gitlab api calls

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,9 +1,16 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+)
+
+var (
+	errAPITimeoutNonPositive = errors.New("--api-timeout must be positive")
 )
 
 // reconcileFlags processes flag values and applies flag priority logic.
@@ -40,6 +47,17 @@ func validateFlags() error {
 	// Validate that both created and updated are not set at the same time
 	if createdFilter && updatedFilter {
 		return fmt.Errorf("--created and --updated cannot be used together, choose one")
+	}
+
+	// Validate API timeout
+	if apiTimeout <= 0 {
+		return fmt.Errorf("%w (got %v)", errAPITimeoutNonPositive, apiTimeout)
+	}
+	if apiTimeout < 5*time.Second {
+		logrus.Warnf("--api-timeout is very short (%v), may cause false timeouts", apiTimeout)
+	}
+	if apiTimeout > 5*time.Minute {
+		logrus.Warnf("--api-timeout is very long (%v), consider using a shorter timeout", apiTimeout)
 	}
 
 	return nil

--- a/cmd/group.go
+++ b/cmd/group.go
@@ -44,6 +44,9 @@ var groupCmd = &cobra.Command{
 			return err
 		}
 
+		// Apply timeout from environment variable if flag not set
+		applyTimeoutFromEnv(cmd.Flags().Changed("api-timeout"))
+
 		// Parse interval if provided
 		beginTime, endTime, err := parseInterval(interval)
 		if err != nil {
@@ -52,7 +55,7 @@ var groupCmd = &cobra.Command{
 		}
 
 		// Create GitLab client
-		app, err := core.NewApp(os.Getenv("GITLAB_TOKEN"), os.Getenv("GITLAB_URI"))
+		app, err := core.NewApp(os.Getenv("GITLAB_TOKEN"), os.Getenv("GITLAB_URI"), apiTimeout)
 		if err != nil {
 			logrus.Errorln(err.Error())
 			return fmt.Errorf("failed to create GitLab client: %w", err)

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -41,6 +41,9 @@ var projectCmd = &cobra.Command{
 			return err
 		}
 
+		// Apply timeout from environment variable if flag not set.
+		applyTimeoutFromEnv(cmd.Flags().Changed("api-timeout"))
+
 		// Parse interval if provided.
 		beginTime, endTime, err := parseInterval(interval)
 		if err != nil {
@@ -59,7 +62,7 @@ var projectCmd = &cobra.Command{
 		}
 
 		// Create GitLab client.
-		app, err := core.NewApp(os.Getenv("GITLAB_TOKEN"), os.Getenv("GITLAB_URI"))
+		app, err := core.NewApp(os.Getenv("GITLAB_TOKEN"), os.Getenv("GITLAB_URI"), apiTimeout)
 		if err != nil {
 			logrus.Errorln(err.Error())
 			return fmt.Errorf("failed to create GitLab client: %w", err)
@@ -163,7 +166,7 @@ func findProject(remoteOrigin string) (project, error) {
 		logrus.Warnf("GITLAB_URI not set, defaulting to %s", gitlabURI)
 	}
 
-	git, err := gitlab.NewClient(gitlabToken, gitlab.WithBaseURL(gitlabURI))
+	git, err := createGitlabClient(gitlabToken, gitlabURI, apiTimeout)
 	if err != nil {
 		logrus.Errorf("Failed to create GitLab client: %v", err)
 		return project{}, fmt.Errorf("failed to create GitLab client: %w", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,23 +2,29 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
+const (
+	defaultAPITimeout = 30 * time.Second // Default timeout for GitLab API requests
+)
+
 // CLI flag variables
 var (
-	logLevel      string // Log level: info, warn, error, debug
-	projectIDFlag int64  // Project ID
-	groupIDFlag   int64  // Group ID
-	createdFilter bool   // Filter by created date
-	updatedFilter bool   // Filter by updated date
-	stateFilter   string // Filter by state: "opened", "closed", "all"
-	formatOutput  string // Output format: "plain", "table", "markdown"
-	debugFlag     bool   // Shorthand for debug logging
-	verboseFlag   bool   // Shorthand for verbose logging
-	interval      string // Date interval
-	mineOption    bool   // Filter issues assigned to current user
+	logLevel      string        // Log level: info, warn, error, debug
+	projectIDFlag int64         // Project ID
+	groupIDFlag   int64         // Group ID
+	createdFilter bool          // Filter by created date
+	updatedFilter bool          // Filter by updated date
+	stateFilter   string        // Filter by state: "opened", "closed", "all"
+	formatOutput  string        // Output format: "plain", "table", "markdown"
+	debugFlag     bool          // Shorthand for debug logging
+	verboseFlag   bool          // Shorthand for verbose logging
+	interval      string        // Date interval
+	mineOption    bool          // Filter issues assigned to current user
+	apiTimeout    time.Duration // API request timeout
 )
 
 // rootCmd represents the base command when called without any subcommands.
@@ -39,6 +45,10 @@ func Execute() error {
 
 func init() {
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
+	// ===== PERSISTENT FLAGS (ALL COMMANDS) =====
+	rootCmd.PersistentFlags().DurationVar(&apiTimeout, "api-timeout", defaultAPITimeout,
+		"Timeout for GitLab API requests (e.g., 30s, 1m)")
 
 	// ===== PROJECT COMMAND FLAGS =====
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -3,6 +3,8 @@ package core
 
 import (
 	"fmt"
+	"net/http"
+	"time"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
@@ -13,8 +15,16 @@ type App struct {
 }
 
 // NewApp creates a new application instance with GitLab client.
-func NewApp(gitlabToken, gitlabURI string) (*App, error) {
-	gitlabClient, err := gitlab.NewClient(gitlabToken, gitlab.WithBaseURL(gitlabURI))
+func NewApp(gitlabToken, gitlabURI string, timeout time.Duration) (*App, error) {
+	httpClient := &http.Client{
+		Timeout: timeout,
+	}
+
+	gitlabClient, err := gitlab.NewClient(
+		gitlabToken,
+		gitlab.WithBaseURL(gitlabURI),
+		gitlab.WithHTTPClient(httpClient),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GitLab client: %w", err)
 	}


### PR DESCRIPTION
- Add --api-timeout CLI flag (default: 30s)
- Add GITLAB_API_TIMEOUT environment variable support
- Create centralized createGitlabClient() factory function
- Update all 4 GitLab client creation points to use timeout
- Add timeout validation with warnings (<5s or >5m)
- Apply timeout to project, group, and whoami commands
- Support flag precedence over environment variable

Resolves #41