### PR TITLE
refactor: fix all linter issues for code quality

### DIFF
--- a/cmd/group.go
+++ b/cmd/group.go
@@ -1,4 +1,3 @@
-// Package cmd provides commands for gitlab-issue-report.
 package cmd
 
 import (

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -1,4 +1,3 @@
-// Package cmd provides commands for gitlab-issue-report.
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,4 @@
+// Package cmd provides commands for gitlab-issue-report.
 package cmd
 
 import (
@@ -11,7 +12,7 @@ const (
 	defaultAPITimeout = 30 * time.Second // Default timeout for GitLab API requests
 )
 
-// CLI flag variables
+// CLI flag variables.
 var (
 	logLevel      string        // Log level: info, warn, error, debug
 	projectIDFlag int64         // Project ID
@@ -56,13 +57,17 @@ func init() {
 	projectCmd.Flags().StringVarP(&interval, "interval", "i", "", "Date interval (e.g., '/-1/ ::' for last month)")
 	projectCmd.Flags().StringVar(&logLevel, "log-level", "error", "Log level: info, warn, error, debug")
 	projectCmd.Flags().BoolVarP(&debugFlag, "debug", "d", false, "Enable debug logging (shorthand for --log-level=debug)")
-	projectCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Enable verbose logging (shorthand for --log-level=info)")
+	projectCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false,
+		"Enable verbose logging (shorthand for --log-level=info)")
 
-	projectCmd.Flags().Int64Var(&projectIDFlag, "project-id", 0, "Project ID to get issues from (auto-detected from git if not set)")
+	projectCmd.Flags().Int64Var(&projectIDFlag, "project-id", 0,
+		"Project ID to get issues from (auto-detected from git if not set)")
 	projectCmd.Flags().Int64VarP(&projectIDFlag, "project", "p", 0, "Project ID (alias for --project-id)")
 
-	projectCmd.Flags().BoolVar(&createdFilter, "created", false, "Filter issues by creation date (requires --interval)")
-	projectCmd.Flags().BoolVarP(&updatedFilter, "updated", "U", false, "Filter issues by update date (requires --interval)")
+	projectCmd.Flags().BoolVar(&createdFilter, "created", false,
+		"Filter issues by creation date (requires --interval)")
+	projectCmd.Flags().BoolVarP(&updatedFilter, "updated", "U", false,
+		"Filter issues by update date (requires --interval)")
 
 	projectCmd.Flags().StringVar(&stateFilter, "state", "", "Filter by state: opened, closed, all")
 	projectCmd.Flags().StringVar(&formatOutput, "format", "plain", "Output format: plain, table, markdown")
@@ -76,8 +81,10 @@ func init() {
 	// Group command flags
 	groupCmd.Flags().StringVarP(&interval, "interval", "i", "", "Date interval (e.g., '/-1/ ::' for last month)")
 	groupCmd.Flags().StringVar(&logLevel, "log-level", "error", "Log level: info, warn, error, debug")
-	groupCmd.Flags().BoolVarP(&debugFlag, "debug", "d", false, "Enable debug logging (shorthand for --log-level=debug)")
-	groupCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Enable verbose logging (shorthand for --log-level=info)")
+	groupCmd.Flags().BoolVarP(&debugFlag, "debug", "d", false,
+		"Enable debug logging (shorthand for --log-level=debug)")
+	groupCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false,
+		"Enable verbose logging (shorthand for --log-level=info)")
 
 	groupCmd.Flags().Int64Var(&groupIDFlag, "group-id", 0, "Group ID to get issues from (required)")
 	groupCmd.Flags().Int64VarP(&groupIDFlag, "group", "g", 0, "Group ID (alias for --group-id)")

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -153,11 +153,12 @@ func addDateFilterOptions(
 	beginTime, endTime time.Time,
 ) []core.GetIssuesOption {
 	if !beginTime.IsZero() {
-		if createdFilter && !updatedFilter {
+		switch {
+		case createdFilter && !updatedFilter:
 			options = append(options, core.WithFilterCreatedAt(beginTime, endTime))
-		} else if updatedFilter && !createdFilter {
+		case updatedFilter && !createdFilter:
 			options = append(options, core.WithFilterUpdatedAt(beginTime, endTime))
-		} else if !createdFilter && !updatedFilter {
+		case !createdFilter && !updatedFilter:
 			// Default behavior: use updated filter when interval is set but no filter specified
 			options = append(options, core.WithFilterUpdatedAt(beginTime, endTime))
 		}

--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -137,7 +137,7 @@ func (a *App) GetIssues(opts ...GetIssuesOption) ([]*gitlab.Issue, error) {
 }
 
 // applyIssueFilters applies common filter settings to issue list options.
-func applyIssueFilters(g *GetIssues, listOptions interface{}) {
+func applyIssueFilters(g *GetIssues, listOptions any) {
 	// Use type switches to handle both project and group issue options
 	switch opts := listOptions.(type) {
 	case *gitlab.ListProjectIssuesOptions:

--- a/internal/render/issues.go
+++ b/internal/render/issues.go
@@ -120,6 +120,7 @@ func (m *MarkdownRenderer) Render(issues []*gitlab.Issue, writer io.Writer) erro
 }
 
 // PrintIssues prints the GitLab issues in a formatted table to stdout.
+//
 // Deprecated: Use Renderer interface instead for better testability.
 func PrintIssues(issues []*gitlab.Issue, printHeader bool) {
 	renderer := NewPlainRenderer(printHeader)
@@ -134,6 +135,7 @@ func truncateStr(str string, length int) string {
 }
 
 // PrintTab prints the GitLab issues in a table format using tablewriter.
+//
 // Deprecated: Use Renderer interface instead for better testability.
 func PrintTab(issues []*gitlab.Issue) {
 	renderer := NewTableRenderer()


### PR DESCRIPTION
- Add static error variables for err113 compliance
- Refactor validateFlags into smaller functions (reduce complexity)
- Replace unused parameter with underscore (revive)
- Convert if-else chain to switch statement (gocritic)
- Fix deprecated comment formatting with blank lines
- Remove duplicate package godoc comments
- Split long lines over 120 characters
- Replace interface{} with any (modernize)

Fixes all 17 linter issues across 7 files