### PR TITLE
fix(security): replace unsafe path concatenation with filepath.Join

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -94,7 +94,7 @@ func findProjectID() (int64, error) {
 	}
 
 	// Get remote origin from git config.
-	configPath := gitFolder + string(os.PathSeparator) + ".git" + string(os.PathSeparator) + "config"
+	configPath := filepath.Join(gitFolder, ".git", "config")
 	remoteOrigin, err := getRemoteOrigin(configPath)
 	if err != nil {
 		return 0, err
@@ -119,7 +119,7 @@ func findGitRepository() (string, error) {
 
 	for cwd != "/" {
 		logrus.Debugln(cwd)
-		stat, err := os.Stat(cwd + string(os.PathSeparator) + ".git")
+		stat, err := os.Stat(filepath.Join(cwd, ".git"))
 		if err == nil {
 			if stat.IsDir() {
 				return cwd, nil // Found git directory.


### PR DESCRIPTION
Replace manual string concatenation with os.PathSeparator with the
standard filepath.Join() function for better security and cross-platform
compatibility.

Changes:
- Replace path concatenation in findProjectID() (config path)
- Replace path concatenation in findGitRepository() (.git detection)

Benefits:
- Prevents potential path traversal vulnerabilities
- Better cross-platform path handling
- More idiomatic and maintainable Go code

Fixes #36