### PR TITLE
refactor(render): remove deprecated PrintIssues and PrintTab functions

### DIFF
--- a/internal/render/issues.go
+++ b/internal/render/issues.go
@@ -4,7 +4,6 @@ package render
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
@@ -119,25 +118,9 @@ func (m *MarkdownRenderer) Render(issues []*gitlab.Issue, writer io.Writer) erro
 	return nil
 }
 
-// PrintIssues prints the GitLab issues in a formatted table to stdout.
-//
-// Deprecated: Use Renderer interface instead for better testability.
-func PrintIssues(issues []*gitlab.Issue, printHeader bool) {
-	renderer := NewPlainRenderer(printHeader)
-	_ = renderer.Render(issues, os.Stdout)
-}
-
 func truncateStr(str string, length int) string {
 	if len(str) > length && length > 0 {
 		return str[:length]
 	}
 	return str
-}
-
-// PrintTab prints the GitLab issues in a table format using tablewriter.
-//
-// Deprecated: Use Renderer interface instead for better testability.
-func PrintTab(issues []*gitlab.Issue) {
-	renderer := NewTableRenderer()
-	_ = renderer.Render(issues, os.Stdout)
 }


### PR DESCRIPTION
Remove unused deprecated functions that were replaced by the Renderer
interface pattern for better testability and flexibility.

Closes #45