### PR TITLE
feat(render): add project path display to issue results

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sgaunet/gitlab-issue-report/internal/core"
+	"github.com/sgaunet/gitlab-issue-report/internal/render"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
@@ -81,7 +82,17 @@ var projectCmd = &cobra.Command{
 			return fmt.Errorf("failed to get issues: %w", err)
 		}
 
-		return renderIssues(issues)
+		// Fetch project path for context
+		projectPath, err := app.GetProjectPath(finalProjectID)
+		if err != nil {
+			logrus.Warnf("Failed to fetch project path: %v", err)
+			// Fall back to rendering without context
+			return renderIssues(issues)
+		}
+
+		// Create context and render
+		context := render.NewProjectContext(projectPath)
+		return renderIssuesWithContext(issues, context)
 	},
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -213,6 +213,11 @@ func initTrace(debugLevel string) {
 
 // renderIssues renders the issues based on the format flag.
 func renderIssues(issues []*gitlab.Issue) error {
+	return renderIssuesWithContext(issues, nil)
+}
+
+// renderIssuesWithContext renders issues with optional rendering context.
+func renderIssuesWithContext(issues []*gitlab.Issue, context *render.Context) error {
 	var renderer render.Renderer
 
 	switch formatOutput {
@@ -226,8 +231,17 @@ func renderIssues(issues []*gitlab.Issue) error {
 		renderer = render.NewPlainRenderer(true)
 	}
 
-	if err := renderer.Render(issues, os.Stdout); err != nil {
-		return fmt.Errorf("failed to render issues: %w", err)
+	// Use context-aware rendering if context is provided
+	if context != nil {
+		if err := renderer.RenderWithContext(issues, context, os.Stdout); err != nil {
+			return fmt.Errorf("failed to render issues: %w", err)
+		}
+	} else {
+		// Fall back to regular rendering
+		if err := renderer.Render(issues, os.Stdout); err != nil {
+			return fmt.Errorf("failed to render issues: %w", err)
+		}
 	}
+
 	return nil
 }

--- a/internal/core/metadata.go
+++ b/internal/core/metadata.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+// GetProjectPath retrieves the path with namespace for a project.
+func (a *App) GetProjectPath(projectID int64) (string, error) {
+	project, _, err := a.gitlabClient.Projects.GetProject(int(projectID), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get project %d: %w", projectID, err)
+	}
+	return project.PathWithNamespace, nil
+}
+
+// GetGroupPath retrieves the full path for a group.
+func (a *App) GetGroupPath(groupID int64) (string, error) {
+	group, _, err := a.gitlabClient.Groups.GetGroup(int(groupID), nil, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get group %d: %w", groupID, err)
+	}
+	return group.FullPath, nil
+}
+
+// GetProjectPathsForIssues builds a map of projectID -> path for all unique projects in issues.
+func (a *App) GetProjectPathsForIssues(issues []*gitlab.Issue) (map[int64]string, error) {
+	// Collect unique project IDs
+	projectIDs := make(map[int64]bool)
+	for _, issue := range issues {
+		projectIDs[issue.ProjectID] = true
+	}
+
+	// Fetch project paths
+	projectPaths := make(map[int64]string)
+	for projectID := range projectIDs {
+		path, err := a.GetProjectPath(projectID)
+		if err != nil {
+			// Log warning but continue with other projects
+			logrus.Warnf("Failed to fetch path for project %d: %v", projectID, err)
+			projectPaths[projectID] = fmt.Sprintf("ID:%d", projectID)
+			continue
+		}
+		projectPaths[projectID] = path
+	}
+
+	return projectPaths, nil
+}

--- a/internal/render/context.go
+++ b/internal/render/context.go
@@ -1,0 +1,36 @@
+package render
+
+// SourceType represents the source of issues (project or group).
+type SourceType string
+
+const (
+	// SourceTypeProject indicates issues from a single project.
+	SourceTypeProject SourceType = "project"
+	// SourceTypeGroup indicates issues from a group (potentially multiple projects).
+	SourceTypeGroup SourceType = "group"
+)
+
+// Context provides contextual information for rendering issues.
+type Context struct {
+	Source      SourceType       // "project" or "group"
+	ProjectPath string           // For single project, e.g., "namespace/project"
+	GroupPath   string           // For group queries, e.g., "namespace/group"
+	ProjectMap  map[int64]string // Maps ProjectID -> PathWithNamespace for multi-project scenarios
+}
+
+// NewProjectContext creates context for single-project rendering.
+func NewProjectContext(projectPath string) *Context {
+	return &Context{
+		Source:      SourceTypeProject,
+		ProjectPath: projectPath,
+	}
+}
+
+// NewGroupContext creates context for group rendering.
+func NewGroupContext(groupPath string, projectMap map[int64]string) *Context {
+	return &Context{
+		Source:     SourceTypeGroup,
+		GroupPath:  groupPath,
+		ProjectMap: projectMap,
+	}
+}

--- a/internal/render/issues.go
+++ b/internal/render/issues.go
@@ -13,9 +13,13 @@ import (
 // Maximum title length for display purposes.
 const maxTitleLength = 70
 
+// Maximum title length when displaying project column (reduced to fit both columns).
+const maxTitleLengthWithProject = 30
+
 // Renderer defines the interface for rendering GitLab issues.
 type Renderer interface {
 	Render(issues []*gitlab.Issue, writer io.Writer) error
+	RenderWithContext(issues []*gitlab.Issue, context *Context, writer io.Writer) error
 }
 
 // PlainRenderer renders issues in plain text format.
@@ -49,6 +53,72 @@ func (p *PlainRenderer) Render(issues []*gitlab.Issue, writer io.Writer) error {
 	return nil
 }
 
+// RenderWithContext renders issues in plain text format with contextual information.
+func (p *PlainRenderer) RenderWithContext(issues []*gitlab.Issue, context *Context, writer io.Writer) error {
+	// Write context header if provided
+	if context != nil {
+		if err := p.writeContextHeader(context, writer); err != nil {
+			return err
+		}
+	}
+
+	// For group queries, add project column
+	if context != nil && context.Source == SourceTypeGroup {
+		return p.renderWithProjectColumn(issues, context, writer)
+	}
+
+	// Fall back to regular rendering for project or no context
+	return p.Render(issues, writer)
+}
+
+// writeContextHeader writes the context header line.
+func (p *PlainRenderer) writeContextHeader(context *Context, writer io.Writer) error {
+	switch context.Source {
+	case SourceTypeProject:
+		if _, err := fmt.Fprintf(writer, "Project: %s\n\n", context.ProjectPath); err != nil {
+			return fmt.Errorf("failed to write project header: %w", err)
+		}
+	case SourceTypeGroup:
+		if _, err := fmt.Fprintf(writer, "Group: %s\n\n", context.GroupPath); err != nil {
+			return fmt.Errorf("failed to write group header: %w", err)
+		}
+	}
+	return nil
+}
+
+// renderWithProjectColumn renders issues with a project column.
+func (p *PlainRenderer) renderWithProjectColumn(
+	issues []*gitlab.Issue,
+	context *Context,
+	writer io.Writer,
+) error {
+	if p.printHeader {
+		headerFormat := "%-40s %-30s %10s %-12s %-12s\n"
+		if _, err := fmt.Fprintf(writer, headerFormat, "Project", "Title", "State", "Created At", "Updated At"); err != nil {
+			return fmt.Errorf("failed to write header: %w", err)
+		}
+	}
+
+	for _, issue := range issues {
+		projectPath := context.ProjectMap[issue.ProjectID]
+		if projectPath == "" {
+			projectPath = fmt.Sprintf("ID:%d", issue.ProjectID)
+		}
+
+		title := truncateStr(issue.Title, maxTitleLengthWithProject)
+		rowFormat := "%-40s %-30s %10s %12s %12s\n"
+		if _, err := fmt.Fprintf(writer, rowFormat,
+			projectPath,
+			title,
+			issue.State,
+			issue.CreatedAt.Format("2006-01-02"),
+			issue.UpdatedAt.Format("2006-01-02")); err != nil {
+			return fmt.Errorf("failed to write issue: %w", err)
+		}
+	}
+	return nil
+}
+
 // TableRenderer renders issues in table format.
 type TableRenderer struct{}
 
@@ -70,6 +140,92 @@ func (t *TableRenderer) Render(issues []*gitlab.Issue, writer io.Writer) error {
 	}
 	if err := table.Render(); err != nil {
 		return fmt.Errorf("error rendering table: %w", err)
+	}
+	return nil
+}
+
+// RenderWithContext renders issues in table format with contextual information.
+func (t *TableRenderer) RenderWithContext(issues []*gitlab.Issue, context *Context, writer io.Writer) error {
+	// Write context header if provided
+	if context != nil {
+		if err := t.writeContextHeader(context, writer); err != nil {
+			return err
+		}
+	}
+
+	table := tablewriter.NewWriter(writer)
+
+	// Adjust headers and data based on context
+	if context != nil && context.Source == SourceTypeGroup {
+		return t.renderGroupTable(table, issues, context)
+	}
+
+	return t.renderRegularTable(table, issues)
+}
+
+// renderGroupTable renders the table with project column for group context.
+func (t *TableRenderer) renderGroupTable(
+	table *tablewriter.Table,
+	issues []*gitlab.Issue,
+	context *Context,
+) error {
+	table.Header([]string{"Project", "Title", "State", "CreatedAt", "UpdatedAt"})
+
+	for _, issue := range issues {
+		projectPath := context.ProjectMap[issue.ProjectID]
+		if projectPath == "" {
+			projectPath = fmt.Sprintf("ID:%d", issue.ProjectID)
+		}
+		row := []string{
+			projectPath,
+			issue.Title,
+			issue.State,
+			issue.CreatedAt.Format("2006-01-02"),
+			issue.UpdatedAt.Format("2006-01-02"),
+		}
+		if err := table.Append(row); err != nil {
+			return fmt.Errorf("error appending table row: %w", err)
+		}
+	}
+
+	if err := table.Render(); err != nil {
+		return fmt.Errorf("error rendering table: %w", err)
+	}
+	return nil
+}
+
+// renderRegularTable renders the table without project column.
+func (t *TableRenderer) renderRegularTable(table *tablewriter.Table, issues []*gitlab.Issue) error {
+	table.Header([]string{"Title", "State", "CreatedAt", "UpdatedAt"})
+	for _, issue := range issues {
+		row := []string{
+			issue.Title,
+			issue.State,
+			issue.CreatedAt.Format("2006-01-02"),
+			issue.UpdatedAt.Format("2006-01-02"),
+		}
+		if err := table.Append(row); err != nil {
+			return fmt.Errorf("error appending table row: %w", err)
+		}
+	}
+
+	if err := table.Render(); err != nil {
+		return fmt.Errorf("error rendering table: %w", err)
+	}
+	return nil
+}
+
+// writeContextHeader writes the context header line for table renderer.
+func (t *TableRenderer) writeContextHeader(context *Context, writer io.Writer) error {
+	switch context.Source {
+	case SourceTypeProject:
+		if _, err := fmt.Fprintf(writer, "Project: %s\n\n", context.ProjectPath); err != nil {
+			return fmt.Errorf("failed to write project header: %w", err)
+		}
+	case SourceTypeGroup:
+		if _, err := fmt.Fprintf(writer, "Group: %s\n\n", context.GroupPath); err != nil {
+			return fmt.Errorf("failed to write group header: %w", err)
+		}
 	}
 	return nil
 }
@@ -106,15 +262,114 @@ func (m *MarkdownRenderer) Render(issues []*gitlab.Issue, writer io.Writer) erro
 		title := strings.ReplaceAll(issue.Title, "|", "\\|")
 		title = strings.ReplaceAll(title, "\n", " ")
 		title = strings.ReplaceAll(title, "\r", " ")
-		
+
 		createdAt := issue.CreatedAt.Format("2006-01-02")
 		updatedAt := issue.UpdatedAt.Format("2006-01-02")
-		
+
 		if _, err := fmt.Fprintf(writer, "| %s | %s | %s | %s |\n", title, issue.State, createdAt, updatedAt); err != nil {
 			return fmt.Errorf("failed to write issue row: %w", err)
 		}
 	}
-	
+
+	return nil
+}
+
+// RenderWithContext renders issues in markdown format with contextual information.
+func (m *MarkdownRenderer) RenderWithContext(issues []*gitlab.Issue, context *Context, writer io.Writer) error {
+	// Generate title with context
+	title := "# GitLab Issues Report\n\n"
+	if context != nil {
+		if context.Source == SourceTypeProject {
+			title = fmt.Sprintf("# GitLab Issues Report - %s\n\n", context.ProjectPath)
+		} else {
+			title = fmt.Sprintf("# GitLab Issues Report - Group: %s\n\n", context.GroupPath)
+		}
+	}
+
+	if len(issues) == 0 {
+		if _, err := fmt.Fprintf(writer, "%sNo issues found.\n", title); err != nil {
+			return fmt.Errorf("failed to write empty message: %w", err)
+		}
+		return nil
+	}
+
+	if _, err := fmt.Fprintf(writer, "%s", title); err != nil {
+		return fmt.Errorf("failed to write title: %w", err)
+	}
+
+	// For group context, add project column
+	if context != nil && context.Source == SourceTypeGroup {
+		return m.renderWithProjectColumn(issues, context, writer)
+	}
+
+	// Regular rendering without project column
+	return m.renderTable(issues, writer)
+}
+
+// renderTable renders the markdown table for issues.
+func (m *MarkdownRenderer) renderTable(issues []*gitlab.Issue, writer io.Writer) error {
+	if _, err := fmt.Fprintf(writer, "| Title | State | Created At | Updated At |\n"); err != nil {
+		return fmt.Errorf("failed to write table header: %w", err)
+	}
+	if _, err := fmt.Fprintf(writer, "|-------|-------|------------|------------|\n"); err != nil {
+		return fmt.Errorf("failed to write table separator: %w", err)
+	}
+
+	for _, issue := range issues {
+		title := strings.ReplaceAll(issue.Title, "|", "\\|")
+		title = strings.ReplaceAll(title, "\n", " ")
+		title = strings.ReplaceAll(title, "\r", " ")
+
+		createdAt := issue.CreatedAt.Format("2006-01-02")
+		updatedAt := issue.UpdatedAt.Format("2006-01-02")
+
+		if _, err := fmt.Fprintf(writer, "| %s | %s | %s | %s |\n", title, issue.State, createdAt, updatedAt); err != nil {
+			return fmt.Errorf("failed to write issue row: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// renderWithProjectColumn renders the markdown table with a project column.
+func (m *MarkdownRenderer) renderWithProjectColumn(
+	issues []*gitlab.Issue,
+	context *Context,
+	writer io.Writer,
+) error {
+	if _, err := fmt.Fprintf(writer, "| Project | Title | State | Created At | Updated At |\n"); err != nil {
+		return fmt.Errorf("failed to write table header: %w", err)
+	}
+	if _, err := fmt.Fprintf(writer, "|---------|-------|-------|------------|------------|\n"); err != nil {
+		return fmt.Errorf("failed to write table separator: %w", err)
+	}
+
+	for _, issue := range issues {
+		projectPath := context.ProjectMap[issue.ProjectID]
+		if projectPath == "" {
+			projectPath = fmt.Sprintf("ID:%d", issue.ProjectID)
+		}
+
+		title := strings.ReplaceAll(issue.Title, "|", "\\|")
+		title = strings.ReplaceAll(title, "\n", " ")
+		title = strings.ReplaceAll(title, "\r", " ")
+
+		createdAt := issue.CreatedAt.Format("2006-01-02")
+		updatedAt := issue.UpdatedAt.Format("2006-01-02")
+
+		if _, err := fmt.Fprintf(
+			writer,
+			"| %s | %s | %s | %s | %s |\n",
+			projectPath,
+			title,
+			issue.State,
+			createdAt,
+			updatedAt,
+		); err != nil {
+			return fmt.Errorf("failed to write issue row: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/render/issues_test.go
+++ b/internal/render/issues_test.go
@@ -262,6 +262,196 @@ func TestRendererInterface(t *testing.T) {
 	var _ Renderer = NewTableRenderer()
 }
 
+// createTestIssuesWithProjects creates test issues with ProjectID set for testing.
+func createTestIssuesWithProjects() []*gitlab.Issue {
+	issues := createTestIssues()
+	issues[0].ProjectID = 100
+	issues[1].ProjectID = 200
+	issues[2].ProjectID = 100
+	return issues
+}
+
+func TestMarkdownRenderer_RenderWithContext_Project(t *testing.T) {
+	issues := createTestIssues()
+	context := NewProjectContext("my-namespace/my-project")
+
+	renderer := NewMarkdownRenderer()
+	var buf bytes.Buffer
+
+	err := renderer.RenderWithContext(issues, context, &buf)
+	if err != nil {
+		t.Errorf("MarkdownRenderer.RenderWithContext() error = %v", err)
+		return
+	}
+
+	output := buf.String()
+	expected := []string{
+		"# GitLab Issues Report - my-namespace/my-project",
+		"| Title | State | Created At | Updated At |",
+	}
+
+	for _, exp := range expected {
+		if !strings.Contains(output, exp) {
+			t.Errorf("Output missing expected string: %q\nGot:\n%s", exp, output)
+		}
+	}
+}
+
+func TestMarkdownRenderer_RenderWithContext_Group(t *testing.T) {
+	issues := createTestIssuesWithProjects()
+
+	projectMap := map[int64]string{
+		100: "namespace/project-a",
+		200: "namespace/project-b",
+	}
+	context := NewGroupContext("my-group", projectMap)
+
+	renderer := NewMarkdownRenderer()
+	var buf bytes.Buffer
+
+	err := renderer.RenderWithContext(issues, context, &buf)
+	if err != nil {
+		t.Errorf("MarkdownRenderer.RenderWithContext() error = %v", err)
+		return
+	}
+
+	output := buf.String()
+	expected := []string{
+		"# GitLab Issues Report - Group: my-group",
+		"| Project | Title | State | Created At | Updated At |",
+		"namespace/project-a",
+		"namespace/project-b",
+	}
+
+	for _, exp := range expected {
+		if !strings.Contains(output, exp) {
+			t.Errorf("Output missing expected string: %q\nGot:\n%s", exp, output)
+		}
+	}
+}
+
+func TestPlainRenderer_RenderWithContext_Project(t *testing.T) {
+	issues := createTestIssues()
+	context := NewProjectContext("my-namespace/my-project")
+
+	renderer := NewPlainRenderer(true)
+	var buf bytes.Buffer
+
+	err := renderer.RenderWithContext(issues, context, &buf)
+	if err != nil {
+		t.Errorf("PlainRenderer.RenderWithContext() error = %v", err)
+		return
+	}
+
+	output := buf.String()
+	expected := []string{
+		"Project: my-namespace/my-project",
+		"Title",
+		"State",
+	}
+
+	for _, exp := range expected {
+		if !strings.Contains(output, exp) {
+			t.Errorf("Output missing expected string: %q\nGot:\n%s", exp, output)
+		}
+	}
+}
+
+func TestPlainRenderer_RenderWithContext_Group(t *testing.T) {
+	issues := createTestIssuesWithProjects()
+
+	projectMap := map[int64]string{
+		100: "namespace/project-a",
+		200: "namespace/project-b",
+	}
+	context := NewGroupContext("my-group", projectMap)
+
+	renderer := NewPlainRenderer(true)
+	var buf bytes.Buffer
+
+	err := renderer.RenderWithContext(issues, context, &buf)
+	if err != nil {
+		t.Errorf("PlainRenderer.RenderWithContext() error = %v", err)
+		return
+	}
+
+	output := buf.String()
+	expected := []string{
+		"Group: my-group",
+		"Project",
+		"Title",
+		"namespace/project-a",
+		"namespace/project-b",
+	}
+
+	for _, exp := range expected {
+		if !strings.Contains(output, exp) {
+			t.Errorf("Output missing expected string: %q\nGot:\n%s", exp, output)
+		}
+	}
+}
+
+func TestTableRenderer_RenderWithContext_Project(t *testing.T) {
+	issues := createTestIssues()
+	context := NewProjectContext("my-namespace/my-project")
+
+	renderer := NewTableRenderer()
+	var buf bytes.Buffer
+
+	err := renderer.RenderWithContext(issues, context, &buf)
+	if err != nil {
+		t.Errorf("TableRenderer.RenderWithContext() error = %v", err)
+		return
+	}
+
+	output := buf.String()
+	expected := []string{
+		"Project: my-namespace/my-project",
+		"TITLE",
+		"STATE",
+	}
+
+	for _, exp := range expected {
+		if !strings.Contains(output, exp) {
+			t.Errorf("Output missing expected string: %q\nGot:\n%s", exp, output)
+		}
+	}
+}
+
+func TestTableRenderer_RenderWithContext_Group(t *testing.T) {
+	issues := createTestIssuesWithProjects()
+
+	projectMap := map[int64]string{
+		100: "namespace/project-a",
+		200: "namespace/project-b",
+	}
+	context := NewGroupContext("my-group", projectMap)
+
+	renderer := NewTableRenderer()
+	var buf bytes.Buffer
+
+	err := renderer.RenderWithContext(issues, context, &buf)
+	if err != nil {
+		t.Errorf("TableRenderer.RenderWithContext() error = %v", err)
+		return
+	}
+
+	output := buf.String()
+	expected := []string{
+		"Group: my-group",
+		"PROJECT",
+		"TITLE",
+		"namespace/project-a",
+		"namespace/project-b",
+	}
+
+	for _, exp := range expected {
+		if !strings.Contains(output, exp) {
+			t.Errorf("Output missing expected string: %q\nGot:\n%s", exp, output)
+		}
+	}
+}
+
 // BenchmarkMarkdownRenderer benchmarks the markdown renderer.
 func BenchmarkMarkdownRenderer(b *testing.B) {
 	issues := createTestIssues()


### PR DESCRIPTION
- Add metadata fetching methods (GetProjectPath, GetGroupPath, GetProjectPathsForIssues)
- Create Context struct for rendering metadata
- Extend Renderer interface with RenderWithContext method
- Display "Project: namespace/project" header for project commands
- Add "Project" column to tables for group commands (multi-project support)
- Implement context-aware rendering for all formats (plain, table, markdown)
- Add comprehensive tests for context-aware rendering
- Include graceful error handling with fallback rendering