### PR TITLE
feat(cmd): add build metadata and --short flag to version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,8 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -X github.com/sgaunet/gitlab-issue-report/cmd.version={{.Version}}
+      - -X github.com/sgaunet/gitlab-issue-report/cmd.commit={{.ShortCommit}}
+      - -X github.com/sgaunet/gitlab-issue-report/cmd.buildDate={{.Date}}
     goos:
       - linux
       - darwin

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,9 +18,14 @@ tasks:
 
   build:
     desc: "Build the binary"
+    vars:
+      COMMIT:
+        sh: git rev-parse --short HEAD 2>/dev/null || echo "unknown"
+      BUILD_DATE:
+        sh: date -u +%Y-%m-%dT%H:%M:%SZ
     cmds:
       - go mod download
-      - CGO_ENABLED=0 go build .
+      - CGO_ENABLED=0 go build -ldflags "-X github.com/sgaunet/gitlab-issue-report/cmd.commit={{.COMMIT}} -X github.com/sgaunet/gitlab-issue-report/cmd.buildDate={{.BUILD_DATE}}" .
 
   install-prereq:
     desc: "Install pre-requisites"

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,29 +2,64 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
 )
 
-var version = "development"
+var (
+	version   = "development"
+	commit    = "unknown"
+	buildDate = "unknown"
+
+	shortVersionFlag bool
+)
+
+// writeVersionInfo writes version information to the given writer.
+// When short is true, only the version string is printed.
+func writeVersionInfo(w io.Writer, short bool) error {
+	if short {
+		if _, err := fmt.Fprintln(w, version); err != nil {
+			return fmt.Errorf("failed to write version: %w", err)
+		}
+		return nil
+	}
+
+	if _, err := fmt.Fprintf(w, "gitlab-issue-report version %s\n", version); err != nil {
+		return fmt.Errorf("failed to write version info: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "  commit: %s\n", commit); err != nil {
+		return fmt.Errorf("failed to write version info: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "  built:  %s\n", buildDate); err != nil {
+		return fmt.Errorf("failed to write version info: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "  go:     %s\n", runtime.Version()); err != nil {
+		return fmt.Errorf("failed to write version info: %w", err)
+	}
+	return nil
+}
 
 // versionCmd represents the version command.
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "print version of gitlab-issue-report",
-	Long:  `print version of gitlab-issue-report`,
-	Run: func(_ *cobra.Command, _ []string) {
-		fmt.Println(version)
+	Short: "Print version and build information",
+	Long: `Print version and build information for gitlab-issue-report.
+
+By default, displays the version, commit hash, build date, and Go version.
+Use --short to print only the version string.
+
+Examples:
+  gitlab-issue-report version
+  gitlab-issue-report version --short`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return writeVersionInfo(os.Stdout, shortVersionFlag)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-	// Here you will define your flags and configuration settings.
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// versionCmd.PersistentFlags().String("foo", "", "A help for foo")
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// versionCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	versionCmd.Flags().BoolVar(&shortVersionFlag, "short", false, "Print only the version string")
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"bytes"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestWriteVersionInfo(t *testing.T) {
+	t.Run("default output includes all metadata", func(t *testing.T) {
+		var buf bytes.Buffer
+		writeVersionInfo(&buf, false)
+		output := buf.String()
+
+		expectedStrings := []string{
+			"gitlab-issue-report version " + version,
+			"commit: " + commit,
+			"built:  " + buildDate,
+			"go:     " + runtime.Version(),
+		}
+
+		for _, expected := range expectedStrings {
+			if !strings.Contains(output, expected) {
+				t.Errorf("default output missing %q\nGot:\n%s", expected, output)
+			}
+		}
+
+		lines := strings.Split(strings.TrimSpace(output), "\n")
+		if len(lines) != 4 {
+			t.Errorf("default output expected 4 lines, got %d\nGot:\n%s", len(lines), output)
+		}
+	})
+
+	t.Run("short output is version only", func(t *testing.T) {
+		var buf bytes.Buffer
+		writeVersionInfo(&buf, true)
+		output := buf.String()
+
+		if strings.TrimSpace(output) != version {
+			t.Errorf("short output = %q, want %q", strings.TrimSpace(output), version)
+		}
+
+		lines := strings.Split(strings.TrimSpace(output), "\n")
+		if len(lines) != 1 {
+			t.Errorf("short output expected 1 line, got %d", len(lines))
+		}
+	})
+
+	t.Run("development defaults display correctly", func(t *testing.T) {
+		// The package-level defaults are "development" and "unknown"
+		// which are set when no ldflags are provided (i.e., during tests).
+		var buf bytes.Buffer
+		writeVersionInfo(&buf, false)
+		output := buf.String()
+
+		if !strings.Contains(output, "development") {
+			t.Error("expected development version in default output")
+		}
+		if !strings.Contains(output, "unknown") {
+			t.Error("expected unknown commit/buildDate in default output")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Enhance `version` command to display app name, commit hash, build date, and Go version (Option 3 from #46)
- Add `--short` flag for backwards-compatible bare version output
- Inject `commit` and `buildDate` via ldflags in `.goreleaser.yml` and `Taskfile.yml`

## Changes

| File | Change |
|------|--------|
| `cmd/version.go` | Add `commit`, `buildDate` vars, `--short` flag, `writeVersionInfo()` with testable `io.Writer` |
| `.goreleaser.yml` | Add `{{.ShortCommit}}` and `{{.Date}}` ldflags |
| `Taskfile.yml` | Inject git commit hash and build date in `task build` |
| `cmd/version_test.go` | Tests for default, short, and development default outputs |

## Example output

**Default:**
```
gitlab-issue-report version 1.0.0
  commit: 02363cc
  built:  2026-02-25T22:23:42Z
  go:     go1.25.4
```

**`--short` (backwards compatible):**
```
1.0.0
```

## Test plan

- [x] `go test ./cmd/ -v -run TestWriteVersionInfo` — 3 subtests pass
- [x] `go test ./...` — full suite (47 tests) pass
- [x] `task lint` — 0 issues
- [x] `task build && ./gitlab-issue-report version` — shows commit/date
- [x] `./gitlab-issue-report version --short` — prints version only

Closes #46