### PR TITLE
feat(issues): add --labels filter and Labels column

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -103,6 +103,16 @@ func TestBuildIssueOptions(t *testing.T) {
 			projectID: 123,
 			groupID:   0,
 		},
+		{
+			name: "with labels filter",
+			opts: commandOptions{
+				formatOutput: "plain",
+				apiTimeout:   defaultAPITimeout,
+				labelsFilter: []string{"bug", "backend"},
+			},
+			projectID: 123,
+			groupID:   0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -415,6 +425,68 @@ func TestStateFilterFunctionality(t *testing.T) {
 			// We can't directly inspect the options, but we can verify the function doesn't panic
 			if options == nil {
 				t.Error("addStatusFilterOptions() returned nil")
+			}
+		})
+	}
+}
+
+// TestAddLabelsFilterOptions tests the labels filter helper.
+func TestAddLabelsFilterOptions(t *testing.T) {
+	tests := []struct {
+		name      string
+		labels    []string
+		wantAdded bool
+	}{
+		{name: "nil labels", labels: nil, wantAdded: false},
+		{name: "empty slice", labels: []string{}, wantAdded: false},
+		{name: "single label", labels: []string{"bug"}, wantAdded: true},
+		{name: "multiple labels", labels: []string{"bug", "backend"}, wantAdded: true},
+		{name: "whitespace and empty entries", labels: []string{"  bug  ", "", "backend"}, wantAdded: true},
+		{name: "only whitespace", labels: []string{"  ", "\t"}, wantAdded: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &commandOptions{
+				labelsFilter: tt.labels,
+				apiTimeout:   defaultAPITimeout,
+			}
+
+			before := []core.GetIssuesOption{}
+			after := addLabelsFilterOptions(o, before)
+			added := len(after) > len(before)
+			if added != tt.wantAdded {
+				t.Errorf("addLabelsFilterOptions() added=%v, want %v", added, tt.wantAdded)
+			}
+		})
+	}
+}
+
+// TestSanitizeLabels tests the sanitizeLabels helper.
+func TestSanitizeLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{name: "nil input", in: nil, want: []string{}},
+		{name: "no changes needed", in: []string{"bug", "backend"}, want: []string{"bug", "backend"}},
+		{name: "trims whitespace", in: []string{"  bug  ", "\tbackend\n"}, want: []string{"bug", "backend"}},
+		{name: "drops empty strings", in: []string{"bug", "", "backend"}, want: []string{"bug", "backend"}},
+		{name: "drops whitespace-only", in: []string{"bug", "   ", "backend"}, want: []string{"bug", "backend"}},
+		{name: "all empty", in: []string{"", "  "}, want: []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeLabels(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("sanitizeLabels() len=%d, want %d (got %v)", len(got), len(tt.want), got)
+			}
+			for i, v := range tt.want {
+				if got[i] != v {
+					t.Errorf("sanitizeLabels()[%d]=%q, want %q", i, got[i], v)
+				}
 			}
 		})
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ type commandOptions struct {
 	verboseFlag   bool          // Shorthand for verbose logging
 	interval      string        // Date interval
 	mineOption    bool          // Filter issues assigned to current user
+	labelsFilter  []string      // Filter issues by labels (AND semantics)
 	apiTimeout    time.Duration // API request timeout
 	timezone      string        // Timezone for date calculations
 }
@@ -72,6 +73,9 @@ EXAMPLES:
 
   # Show only issues assigned to you
   gitlab-issue-report project --mine
+
+  # Filter by labels (issues must have ALL listed labels)
+  gitlab-issue-report project --labels bug,backend
 
   # Use a specific timezone for date calculations
   gitlab-issue-report project -i "/-7/ ::" --timezone "America/New_York"
@@ -121,6 +125,8 @@ func init() {
 	projectCmd.Flags().StringVar(&opts.formatOutput, "format", "plain", "Output format: plain, table, markdown")
 
 	projectCmd.Flags().BoolVarP(&opts.mineOption, "mine", "M", false, "Only issues assigned to current user")
+	projectCmd.Flags().StringSliceVarP(&opts.labelsFilter, "labels", "l", nil,
+		"Filter by labels (comma-separated or repeated; issue must have ALL listed labels)")
 
 	rootCmd.AddCommand(projectCmd)
 
@@ -145,6 +151,8 @@ func init() {
 	groupCmd.Flags().StringVar(&opts.formatOutput, "format", "plain", "Output format: plain, table, markdown")
 
 	groupCmd.Flags().BoolVarP(&opts.mineOption, "mine", "M", false, "Only issues assigned to current user")
+	groupCmd.Flags().StringSliceVarP(&opts.labelsFilter, "labels", "l", nil,
+		"Filter by labels (comma-separated or repeated; issue must have ALL listed labels)")
 
 	rootCmd.AddCommand(groupCmd)
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/sgaunet/calcdate/calcdatelib"
@@ -179,6 +180,9 @@ func buildIssueOptions(
 		return nil, err
 	}
 
+	// Add labels filter options
+	options = addLabelsFilterOptions(o, options)
+
 	return options, nil
 }
 
@@ -239,6 +243,26 @@ func addAssigneeFilterOptions(o *commandOptions, options []core.GetIssuesOption)
 		options = append(options, core.WithAssigneeUsername(username))
 	}
 	return options, nil
+}
+
+// addLabelsFilterOptions adds labels filter options if any labels are specified.
+func addLabelsFilterOptions(o *commandOptions, options []core.GetIssuesOption) []core.GetIssuesOption {
+	labels := sanitizeLabels(o.labelsFilter)
+	if len(labels) > 0 {
+		options = append(options, core.WithLabels(labels))
+	}
+	return options
+}
+
+// sanitizeLabels trims whitespace and drops empty entries.
+func sanitizeLabels(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, l := range in {
+		if t := strings.TrimSpace(l); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 // initTrace initializes the logging based on debug level.

--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -27,6 +27,7 @@ type GetIssues struct {
 	FilterUpdatedAtAfter  time.Time
 	FilterUpdatedAtBefore time.Time
 	AssigneeUsername      string
+	Labels                []string
 }
 
 // GetIssuesOption is a functional option for configuring the GetIssues struct.
@@ -118,6 +119,13 @@ func WithAssigneeUsername(assigneeUsername string) GetIssuesOption {
 	}
 }
 
+// WithLabels filters issues that have all of the specified labels.
+func WithLabels(labels []string) GetIssuesOption {
+	return func(g *GetIssues) {
+		g.Labels = labels
+	}
+}
+
 // GetIssues retrieves GitLab issues based on the provided options.
 func (a *App) GetIssues(opts ...GetIssuesOption) ([]*gitlab.Issue, error) {
 	g := &GetIssues{}
@@ -153,6 +161,10 @@ func applyIssueFilters(g *GetIssues, listOptions any) {
 		if g.AssigneeUsername != "" {
 			opts.AssigneeUsername = &g.AssigneeUsername
 		}
+		if len(g.Labels) > 0 {
+			labels := gitlab.LabelOptions(g.Labels)
+			opts.Labels = &labels
+		}
 	case *gitlab.ListGroupIssuesOptions:
 		applyCommonFilters(
 			g,
@@ -165,6 +177,10 @@ func applyIssueFilters(g *GetIssues, listOptions any) {
 		// Add assignee username filter
 		if g.AssigneeUsername != "" {
 			opts.AssigneeUsername = &g.AssigneeUsername
+		}
+		if len(g.Labels) > 0 {
+			labels := gitlab.LabelOptions(g.Labels)
+			opts.Labels = &labels
 		}
 	}
 }

--- a/internal/render/issues.go
+++ b/internal/render/issues.go
@@ -35,8 +35,9 @@ func NewPlainRenderer(printHeader bool) *PlainRenderer {
 // Render renders issues in plain text format.
 func (p *PlainRenderer) Render(issues []*gitlab.Issue, writer io.Writer) error {
 	if p.printHeader {
-		headerFormat := "%-70s %10s %-12s %-12s\n"
-		if _, err := fmt.Fprintf(writer, headerFormat, "Title", "State", "Created At", "Updated At"); err != nil {
+		headerFormat := "%-70s %10s %-12s %-12s %s\n"
+		if _, err := fmt.Fprintf(writer, headerFormat,
+			"Title", "State", "Created At", "Updated At", "Labels"); err != nil {
 			return fmt.Errorf("failed to write header: %w", err)
 		}
 	}
@@ -45,8 +46,9 @@ func (p *PlainRenderer) Render(issues []*gitlab.Issue, writer io.Writer) error {
 		state := issues[idx].State
 		createdAt := issues[idx].CreatedAt.Format("2006-01-02")
 		updatedAt := issues[idx].UpdatedAt.Format("2006-01-02")
-		rowFormat := "%-70s %10s %12s %12s\n"
-		if _, err := fmt.Fprintf(writer, rowFormat, title, state, createdAt, updatedAt); err != nil {
+		labels := formatLabels(issues[idx].Labels)
+		rowFormat := "%-70s %10s %12s %12s %s\n"
+		if _, err := fmt.Fprintf(writer, rowFormat, title, state, createdAt, updatedAt, labels); err != nil {
 			return fmt.Errorf("failed to write issue: %w", err)
 		}
 	}
@@ -93,8 +95,9 @@ func (p *PlainRenderer) renderWithProjectColumn(
 	writer io.Writer,
 ) error {
 	if p.printHeader {
-		headerFormat := "%-40s %-30s %10s %-12s %-12s\n"
-		if _, err := fmt.Fprintf(writer, headerFormat, "Project", "Title", "State", "Created At", "Updated At"); err != nil {
+		headerFormat := "%-40s %-30s %10s %-12s %-12s %s\n"
+		if _, err := fmt.Fprintf(writer, headerFormat,
+			"Project", "Title", "State", "Created At", "Updated At", "Labels"); err != nil {
 			return fmt.Errorf("failed to write header: %w", err)
 		}
 	}
@@ -106,13 +109,14 @@ func (p *PlainRenderer) renderWithProjectColumn(
 		}
 
 		title := truncateStr(issue.Title, maxTitleLengthWithProject)
-		rowFormat := "%-40s %-30s %10s %12s %12s\n"
+		rowFormat := "%-40s %-30s %10s %12s %12s %s\n"
 		if _, err := fmt.Fprintf(writer, rowFormat,
 			projectPath,
 			title,
 			issue.State,
 			issue.CreatedAt.Format("2006-01-02"),
-			issue.UpdatedAt.Format("2006-01-02")); err != nil {
+			issue.UpdatedAt.Format("2006-01-02"),
+			formatLabels(issue.Labels)); err != nil {
 			return fmt.Errorf("failed to write issue: %w", err)
 		}
 	}
@@ -130,10 +134,16 @@ func NewTableRenderer() *TableRenderer {
 // Render renders issues in table format.
 func (t *TableRenderer) Render(issues []*gitlab.Issue, writer io.Writer) error {
 	table := tablewriter.NewWriter(writer)
-	table.Header([]string{"Title", "State", "CreatedAt", "UpdatedAt"})
+	table.Header([]string{"Title", "State", "CreatedAt", "UpdatedAt", "Labels"})
 
 	for _, v := range issues {
-		row := []string{v.Title, v.State, v.CreatedAt.Format("2006-01-02"), v.UpdatedAt.Format("2006-01-02")}
+		row := []string{
+			v.Title,
+			v.State,
+			v.CreatedAt.Format("2006-01-02"),
+			v.UpdatedAt.Format("2006-01-02"),
+			formatLabels(v.Labels),
+		}
 		if err := table.Append(row); err != nil {
 			return fmt.Errorf("error appending table row: %w", err)
 		}
@@ -169,7 +179,7 @@ func (t *TableRenderer) renderGroupTable(
 	issues []*gitlab.Issue,
 	context *Context,
 ) error {
-	table.Header([]string{"Project", "Title", "State", "CreatedAt", "UpdatedAt"})
+	table.Header([]string{"Project", "Title", "State", "CreatedAt", "UpdatedAt", "Labels"})
 
 	for _, issue := range issues {
 		projectPath := context.ProjectMap[issue.ProjectID]
@@ -182,6 +192,7 @@ func (t *TableRenderer) renderGroupTable(
 			issue.State,
 			issue.CreatedAt.Format("2006-01-02"),
 			issue.UpdatedAt.Format("2006-01-02"),
+			formatLabels(issue.Labels),
 		}
 		if err := table.Append(row); err != nil {
 			return fmt.Errorf("error appending table row: %w", err)
@@ -196,13 +207,14 @@ func (t *TableRenderer) renderGroupTable(
 
 // renderRegularTable renders the table without project column.
 func (t *TableRenderer) renderRegularTable(table *tablewriter.Table, issues []*gitlab.Issue) error {
-	table.Header([]string{"Title", "State", "CreatedAt", "UpdatedAt"})
+	table.Header([]string{"Title", "State", "CreatedAt", "UpdatedAt", "Labels"})
 	for _, issue := range issues {
 		row := []string{
 			issue.Title,
 			issue.State,
 			issue.CreatedAt.Format("2006-01-02"),
 			issue.UpdatedAt.Format("2006-01-02"),
+			formatLabels(issue.Labels),
 		}
 		if err := table.Append(row); err != nil {
 			return fmt.Errorf("error appending table row: %w", err)
@@ -250,10 +262,10 @@ func (m *MarkdownRenderer) Render(issues []*gitlab.Issue, writer io.Writer) erro
 	if _, err := fmt.Fprintf(writer, "# GitLab Issues Report\n\n"); err != nil {
 		return fmt.Errorf("failed to write title: %w", err)
 	}
-	if _, err := fmt.Fprintf(writer, "| Title | State | Created At | Updated At |\n"); err != nil {
+	if _, err := fmt.Fprintf(writer, "| Title | State | Created At | Updated At | Labels |\n"); err != nil {
 		return fmt.Errorf("failed to write table header: %w", err)
 	}
-	if _, err := fmt.Fprintf(writer, "|-------|-------|------------|------------|\n"); err != nil {
+	if _, err := fmt.Fprintf(writer, "|-------|-------|------------|------------|--------|\n"); err != nil {
 		return fmt.Errorf("failed to write table separator: %w", err)
 	}
 
@@ -265,8 +277,10 @@ func (m *MarkdownRenderer) Render(issues []*gitlab.Issue, writer io.Writer) erro
 
 		createdAt := issue.CreatedAt.Format("2006-01-02")
 		updatedAt := issue.UpdatedAt.Format("2006-01-02")
+		labels := strings.ReplaceAll(formatLabels(issue.Labels), "|", "\\|")
 
-		if _, err := fmt.Fprintf(writer, "| %s | %s | %s | %s |\n", title, issue.State, createdAt, updatedAt); err != nil {
+		if _, err := fmt.Fprintf(writer, "| %s | %s | %s | %s | %s |\n",
+			title, issue.State, createdAt, updatedAt, labels); err != nil {
 			return fmt.Errorf("failed to write issue row: %w", err)
 		}
 	}
@@ -308,10 +322,10 @@ func (m *MarkdownRenderer) RenderWithContext(issues []*gitlab.Issue, context *Co
 
 // renderTable renders the markdown table for issues.
 func (m *MarkdownRenderer) renderTable(issues []*gitlab.Issue, writer io.Writer) error {
-	if _, err := fmt.Fprintf(writer, "| Title | State | Created At | Updated At |\n"); err != nil {
+	if _, err := fmt.Fprintf(writer, "| Title | State | Created At | Updated At | Labels |\n"); err != nil {
 		return fmt.Errorf("failed to write table header: %w", err)
 	}
-	if _, err := fmt.Fprintf(writer, "|-------|-------|------------|------------|\n"); err != nil {
+	if _, err := fmt.Fprintf(writer, "|-------|-------|------------|------------|--------|\n"); err != nil {
 		return fmt.Errorf("failed to write table separator: %w", err)
 	}
 
@@ -322,8 +336,10 @@ func (m *MarkdownRenderer) renderTable(issues []*gitlab.Issue, writer io.Writer)
 
 		createdAt := issue.CreatedAt.Format("2006-01-02")
 		updatedAt := issue.UpdatedAt.Format("2006-01-02")
+		labels := strings.ReplaceAll(formatLabels(issue.Labels), "|", "\\|")
 
-		if _, err := fmt.Fprintf(writer, "| %s | %s | %s | %s |\n", title, issue.State, createdAt, updatedAt); err != nil {
+		if _, err := fmt.Fprintf(writer, "| %s | %s | %s | %s | %s |\n",
+			title, issue.State, createdAt, updatedAt, labels); err != nil {
 			return fmt.Errorf("failed to write issue row: %w", err)
 		}
 	}
@@ -337,10 +353,10 @@ func (m *MarkdownRenderer) renderWithProjectColumn(
 	context *Context,
 	writer io.Writer,
 ) error {
-	if _, err := fmt.Fprintf(writer, "| Project | Title | State | Created At | Updated At |\n"); err != nil {
+	if _, err := fmt.Fprintf(writer, "| Project | Title | State | Created At | Updated At | Labels |\n"); err != nil {
 		return fmt.Errorf("failed to write table header: %w", err)
 	}
-	if _, err := fmt.Fprintf(writer, "|---------|-------|-------|------------|------------|\n"); err != nil {
+	if _, err := fmt.Fprintf(writer, "|---------|-------|-------|------------|------------|--------|\n"); err != nil {
 		return fmt.Errorf("failed to write table separator: %w", err)
 	}
 
@@ -356,15 +372,17 @@ func (m *MarkdownRenderer) renderWithProjectColumn(
 
 		createdAt := issue.CreatedAt.Format("2006-01-02")
 		updatedAt := issue.UpdatedAt.Format("2006-01-02")
+		labels := strings.ReplaceAll(formatLabels(issue.Labels), "|", "\\|")
 
 		if _, err := fmt.Fprintf(
 			writer,
-			"| %s | %s | %s | %s | %s |\n",
+			"| %s | %s | %s | %s | %s | %s |\n",
 			projectPath,
 			title,
 			issue.State,
 			createdAt,
 			updatedAt,
+			labels,
 		); err != nil {
 			return fmt.Errorf("failed to write issue row: %w", err)
 		}
@@ -378,4 +396,9 @@ func truncateStr(str string, length int) string {
 		return str[:length]
 	}
 	return str
+}
+
+// formatLabels joins issue labels with ", " for display.
+func formatLabels(labels gitlab.Labels) string {
+	return strings.Join([]string(labels), ", ")
 }

--- a/internal/render/issues_test.go
+++ b/internal/render/issues_test.go
@@ -13,7 +13,7 @@ import (
 func createTestIssues() []*gitlab.Issue {
 	now := time.Now()
 	yesterday := now.AddDate(0, 0, -1)
-	
+
 	return []*gitlab.Issue{
 		{
 			ID:        1,
@@ -21,6 +21,7 @@ func createTestIssues() []*gitlab.Issue {
 			State:     "opened",
 			CreatedAt: &yesterday,
 			UpdatedAt: &now,
+			Labels:    gitlab.Labels{"bug", "backend"},
 		},
 		{
 			ID:        2,
@@ -35,6 +36,7 @@ func createTestIssues() []*gitlab.Issue {
 			State:     "opened",
 			CreatedAt: &yesterday,
 			UpdatedAt: &now,
+			Labels:    gitlab.Labels{"docs"},
 		},
 	}
 }
@@ -260,6 +262,70 @@ func TestRendererInterface(t *testing.T) {
 	var _ Renderer = NewMarkdownRenderer()
 	var _ Renderer = NewPlainRenderer(true)
 	var _ Renderer = NewTableRenderer()
+}
+
+// TestRenderers_Labels verifies that issue labels appear in the output of every renderer.
+func TestRenderers_Labels(t *testing.T) {
+	issues := createTestIssues()
+
+	tests := []struct {
+		name     string
+		renderer Renderer
+		expected []string
+	}{
+		{
+			name:     "plain renderer includes Labels header and values",
+			renderer: NewPlainRenderer(true),
+			expected: []string{"Labels", "bug, backend", "docs"},
+		},
+		{
+			name:     "table renderer includes LABELS header and values",
+			renderer: NewTableRenderer(),
+			expected: []string{"LABELS", "bug, backend", "docs"},
+		},
+		{
+			name:     "markdown renderer includes Labels column and values",
+			renderer: NewMarkdownRenderer(),
+			expected: []string{"| Labels |", "| bug, backend |", "| docs |"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := tt.renderer.Render(issues, &buf); err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+			output := buf.String()
+			for _, exp := range tt.expected {
+				if !strings.Contains(output, exp) {
+					t.Errorf("output missing %q\nGot:\n%s", exp, output)
+				}
+			}
+		})
+	}
+}
+
+// TestFormatLabels tests the formatLabels helper.
+func TestFormatLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		in   gitlab.Labels
+		want string
+	}{
+		{name: "nil labels", in: nil, want: ""},
+		{name: "empty labels", in: gitlab.Labels{}, want: ""},
+		{name: "single label", in: gitlab.Labels{"bug"}, want: "bug"},
+		{name: "multiple labels", in: gitlab.Labels{"bug", "backend"}, want: "bug, backend"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatLabels(tt.in); got != tt.want {
+				t.Errorf("formatLabels() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }
 
 // createTestIssuesWithProjects creates test issues with ProjectID set for testing.


### PR DESCRIPTION
- Add --labels/-l flag (StringSliceVarP) on project and group commands
- Extend core.GetIssues with Labels and WithLabels option; wire through
  applyIssueFilters for both project and group API options
- Sanitize labels: trim whitespace, drop empty entries
- Display Labels column in plain, table, and markdown renderers
  (regular and with-project-column variants)
- Cover with unit tests for filter helpers and renderer output

Closes #86